### PR TITLE
Serialize events

### DIFF
--- a/src/controllers/dashboard.ts
+++ b/src/controllers/dashboard.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from 'express';
+import { pool } from "../db/db"
+import { eventsSerializer } from "../models/events"
+
+export const userEvents = async (req: Request, res: Response) => {
+  const user = await pool.query("SELECT user_name, secret_key FROM users WHERE user_name = $1", [req.user.user]);
+  const response = {user: user.rows[0],
+                    events: await eventsSerializer(user.rows[0].user_name)}
+  res.json(response);
+}
+
+export default userEvents

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -44,3 +44,28 @@ export const insertEvent = async (encryptedEvent: string) => {
         const eventObject = await pool.query('INSERT INTO events (encrypted_event) VALUES ($1) RETURNING *', [encryptedEvent])
         return eventObject.rows[0].event_id
 }
+
+export const userEventLookup = async (user_id: string) => {
+  const events = await pool.query('SELECT event_id, creator from user_event WHERE user_id = $1', [user_id])
+  return events.rows
+}
+
+export const eventSorter = (events: any[]) => {
+  const sorted_events = {myEvents: [""],
+                        invitedEvents: [""] }
+  events.forEach(row => {
+    if(row.creator === true){
+      sorted_events.myEvents.push(row.event_id)
+    }else{
+      sorted_events.invitedEvents.push(row.event_id)
+    }
+  });
+
+  return sorted_events
+}
+
+export const eventsSerializer = async (username: string) => {
+  const user_id = await lookupUserIDs(username)
+  const events = await userEventLookup(user_id)
+  return eventSorter(events)
+}

--- a/src/routes/dashboard.ts
+++ b/src/routes/dashboard.ts
@@ -1,12 +1,16 @@
 import { Router, Request, Response } from 'express';
-import { pool } from '../db/db';
+import userEvents from "../controllers/dashboard"
 
 import { authorizer } from '../middleware/authorization';
 const router = Router();
 
 router.get('/dashboard', authorizer, async (req: Request, res: Response) => {
-  const user = await pool.query("SELECT user_name, secret_key FROM users WHERE user_name = $1", [req.user.user]);
-  res.json(user.rows[0]);
+  try {    
+    userEvents(req, res)
+  } catch (err) {
+    console.error(err.message);
+    res.status(500).send('Server Error');
+  }
 });
 
 export { router };

--- a/src/test/models/events.test.ts
+++ b/src/test/models/events.test.ts
@@ -1,4 +1,4 @@
-import { insertEvent, findCreator, addUsersToEvent } from "../../models/events";
+import { insertEvent, findCreator, addUsersToEvent, userEventLookup, eventSorter, eventsSerializer} from "../../models/events";
 import { insertUser } from '../../models/auth';
 import { setup, teardown } from "../setupTeardown"
 import { genJWT } from "../../models/jwt"
@@ -20,13 +20,38 @@ it("returns the creator user object", async () => {
   expect(creator.user_name).toBe("test")
 })
 
+it('looks up events from a user', async () => {
+  const creator = await findCreator(token)
+  const event_id = await insertEvent(encryptedEvent)
+  await addUsersToEvent([creator], event_id, creator.user_id)
+  const events = await userEventLookup(creator.user_id)
+  expect(events[0].creator).toBe(true);
+});
+
+it('sorts events into creator or invitee', async () => {
+  const events = [{"creator": true, "event_id": "02001244-0da2-4876-952e-5f42c5e243fd"},
+  {"creator": false, "event_id": "02001244-0da2-4876-952e-5f42c5e243fd"}]
+  const sortedEevents = eventSorter(events)
+  expect(sortedEevents).toStrictEqual({"invitedEvents": ["", "02001244-0da2-4876-952e-5f42c5e243fd"], "myEvents": ["", "02001244-0da2-4876-952e-5f42c5e243fd"]});
+});
+it('creates two arrays if no events are submitted', async () => {
+  const events: any[] = []
+  const sortedEevents = eventSorter(events)
+  expect(sortedEevents).toStrictEqual({"invitedEvents": [""], "myEvents": [""]});
+});
+
+it('returns empty arrays when no events are found', async () => {
+  const creator = await insertUser("noEventsUser", "test2", "secretKeyTest");
+  const events = await eventsSerializer(creator.user_name)
+  expect(events).toStrictEqual({"invitedEvents": [""], "myEvents": [""]})
+});
+
 it("adds relations of users and events", async () => {
   const invitees = ["test2", "test1", "test3"]
   const event_id = await insertEvent(encryptedEvent)
   const creator = await findCreator(token)
 
   invitees.forEach(async (user) => { await insertUser(user, "test2", "secretKeyTest"); });
-
   await addUsersToEvent(invitees, event_id, creator.user_id)
   const finalCount = (await pool.query('SELECT * from user_event WHERE event_id = $1', [event_id])).rows.length
   expect(finalCount).toBe(3)


### PR DESCRIPTION
Serialized events into `/dashboard` so that user info and their events were returned.
Events are sorted into arrays `myEvents` and `inviteeEvents`. If no events are returned empty arrays are still formed.
Tests pass for eventsSerializer, userEventLookup, and eventSorter.